### PR TITLE
feat: Implement driver and warehouse manager registration component a…

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,12 +3,14 @@ import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }), 
+    provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAnimations(),
+    provideHttpClient(withInterceptorsFromDi()),
   ]
 };
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import { TransactionsComponent } from './components/warehouse-manager-page/trans
 import { TruckTrackingComponent } from './components/warehouse-manager-page/truck-tracking/truck-tracking.component';
 import { VendorOrdersComponent } from './components/warehouse-manager-page/vendor-orders/vendor-orders.component';
 import { SupplierReqSurveyComponent } from './components/warehouse-manager-page/supplier-req-survey/supplier-req-survey.component';
+import { DriverManagerRegisterComponent } from './components/admin-page/driver-manager-register/driver-manager-register.component';
 
 export const routes: Routes = [
   {
@@ -76,6 +77,7 @@ export const routes: Routes = [
             component: ForecastComponent,
             pathMatch: 'full',
           },
+          { path: 'register', component: DriverManagerRegisterComponent },
           // rest (modify sidebar.ts as well)
           { path: '**', redirectTo: '', pathMatch: 'full' }
         ]

--- a/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.css
+++ b/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.css
@@ -1,0 +1,19 @@
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  
+  .animate-fadeIn {
+    animation: fadeIn 0.3s ease-in-out;
+  }
+  
+  /* Make inputs have a subtle hover effect */
+  input:hover, select:hover {
+    border-color: #cbd5e0;
+  }
+  
+  /* Add focus styling */
+  input:focus, select:focus {
+    border-color: #3b82f6;
+    outline: 2px solid #bfdbfe;
+  }

--- a/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.html
+++ b/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.html
@@ -1,0 +1,606 @@
+<div class="container mx-auto px-4 py-8 bg-gray-50 backdrop-blur-sm">
+  <h1
+    class="text-3xl font-bold text-left pl-3"
+  >
+    User Registration
+  </h1>
+  <p class="text-gray-700 pl-3 mb-4">
+    Use this form to add drivers or warehouse managers to your supply chain system.
+  </p>
+
+  <!-- Tabs with modern styling -->
+  <div class="flex mb-8 bg-white/30 p-1 rounded-lg shadow-sm">
+    <button
+      [ngClass]="{
+        ' bg-[#f19249] hover:bg-[#fcd9b1] text-white shadow-md transform scale-105':
+          activeTab === 'driver',
+        'bg-gray-100 text-gray-700 hover:bg-gray-200': activeTab !== 'driver'
+      }"
+      class="flex-1 py-3 px-4 font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2"
+      (click)="setActiveTab('driver')"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+        />
+      </svg>
+      Driver Registration
+    </button>
+    <button
+      [ngClass]="{
+        ' bg-[#f19249] hover:bg-[#fcd9b1] text-white shadow-md transform scale-105':
+          activeTab === 'warehouseManager',
+        'bg-gray-100 text-gray-700 hover:bg-gray-200':
+          activeTab !== 'warehouseManager'
+      }"
+      class="flex-1 py-3 px-4 font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2"
+      (click)="setActiveTab('warehouseManager')"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+        />
+      </svg>
+      Warehouse Manager Registration
+    </button>
+  </div>
+
+  <!-- Response Message with animation -->
+  <div
+    *ngIf="submitStatus"
+    [ngClass]="{
+      'bg-green-50 border-green-500': submitStatus.success,
+      'bg-red-50 border-red-500': !submitStatus.success
+    }"
+    class="mb-6 p-4 border-l-4 rounded-md shadow-sm animate-fadeIn"
+  >
+    <div class="flex items-center">
+      <svg
+        *ngIf="submitStatus.success"
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5 text-green-600 mr-2"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+      <svg
+        *ngIf="!submitStatus.success"
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5 text-red-600 mr-2"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
+      <p
+        [ngClass]="{
+          'text-green-700': submitStatus.success,
+          'text-red-700': !submitStatus.success
+        }"
+      >
+        {{ submitStatus.message }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Driver Registration Form with enhanced styling -->
+  <div
+    *ngIf="activeTab === 'driver'"
+    class="bg-white rounded-lg shadow-lg p-6 transition-all duration-300"
+  >
+    <h2 class="text-xl font-semibold mb-5 text-gray-800 border-b pb-2">
+      Driver Registration Form
+    </h2>
+
+    <form
+      [formGroup]="driverForm"
+      (ngSubmit)="onDriverSubmit()"
+      class="space-y-4"
+    >
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <!-- Username -->
+        <div class="space-y-2">
+          <label for="username" class="block text-sm font-medium text-gray-700"
+            >Username</label
+          >
+          <input
+            type="text"
+            id="username"
+            formControlName="username"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter username"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'username', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Username is required
+          </div>
+          <div
+            *ngIf="hasError(driverForm, 'username', 'minlength')"
+            class="text-red-500 text-xs"
+          >
+            Username must be at least 3 characters
+          </div>
+        </div>
+
+        <!-- Email -->
+        <div class="space-y-2">
+          <label for="email" class="block text-sm font-medium text-gray-700"
+            >Email</label
+          >
+          <input
+            type="email"
+            id="email"
+            formControlName="email"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter email"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'email', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Email is required
+          </div>
+          <div
+            *ngIf="hasError(driverForm, 'email', 'email')"
+            class="text-red-500 text-xs"
+          >
+            Please enter a valid email
+          </div>
+        </div>
+
+        <!-- Password -->
+        <div class="space-y-2">
+          <label for="password" class="block text-sm font-medium text-gray-700"
+            >Password</label
+          >
+          <input
+            type="password"
+            id="password"
+            formControlName="password"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter password"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'password', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Password is required
+          </div>
+          <div
+            *ngIf="hasError(driverForm, 'password', 'minlength')"
+            class="text-red-500 text-xs"
+          >
+            Password must be at least 8 characters
+          </div>
+        </div>
+
+        <!-- First Name -->
+        <div class="space-y-2">
+          <label
+            for="first_name"
+            class="block text-sm font-medium text-gray-700"
+            >First Name</label
+          >
+          <input
+            type="text"
+            id="first_name"
+            formControlName="first_name"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter first name"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'first_name', 'required')"
+            class="text-red-500 text-xs"
+          >
+            First name is required
+          </div>
+        </div>
+
+        <!-- Last Name -->
+        <div class="space-y-2">
+          <label for="last_name" class="block text-sm font-medium text-gray-700"
+            >Last Name</label
+          >
+          <input
+            type="text"
+            id="last_name"
+            formControlName="last_name"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter last name"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'last_name', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Last name is required
+          </div>
+        </div>
+
+        <!-- Vehicle ID -->
+        <div class="space-y-2">
+          <label
+            for="vehicle_id"
+            class="block text-sm font-medium text-gray-700"
+            >Vehicle ID</label
+          >
+          <input
+            type="text"
+            id="vehicle_id"
+            formControlName="vehicle_id"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter vehicle ID"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'vehicle_id', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Vehicle ID is required
+          </div>
+        </div>
+
+        <!-- License Number -->
+        <div class="space-y-2">
+          <label
+            for="license_number"
+            class="block text-sm font-medium text-gray-700"
+            >License Number</label
+          >
+          <input
+            type="text"
+            id="license_number"
+            formControlName="license_number"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter license number"
+          />
+          <div
+            *ngIf="hasError(driverForm, 'license_number', 'required')"
+            class="text-red-500 text-xs"
+          >
+            License number is required
+          </div>
+        </div>
+
+        <!-- Vehicle Type -->
+        <div class="space-y-2">
+          <label
+            for="vehicle_type"
+            class="block text-sm font-medium text-gray-700"
+            >Vehicle Type</label
+          >
+          <select
+            id="vehicle_type"
+            formControlName="vehicle_type"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            <option value="lorry">Lorry</option>
+            <option value="truck">Truck</option>
+            <option value="van">Van</option>
+          </select>
+          <div
+            *ngIf="hasError(driverForm, 'vehicle_type', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Vehicle type is required
+          </div>
+        </div>
+      </div>
+
+      <div class="flex justify-end mt-6">
+        <button
+          type="submit"
+          [disabled]="isSubmitting"
+          class="px-6 py-2 bg-[#f19249] hover:bg-[#fcd9b1] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 transform hover:scale-105 active:scale-95 shadow-md"
+        >
+          <span class="flex items-center">
+            <svg
+              *ngIf="isSubmitting"
+              class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+            {{ isSubmitting ? "Registering..." : "Register Driver" }}
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <!-- Warehouse Manager Registration Form with enhanced styling -->
+  <div
+    *ngIf="activeTab === 'warehouseManager'"
+    class="bg-white rounded-lg shadow-lg p-6 transition-all duration-300"
+  >
+    <h2 class="text-xl font-semibold mb-5 text-gray-800 border-b pb-2">
+      Warehouse Manager Registration Form
+    </h2>
+
+    <form
+      [formGroup]="warehouseManagerForm"
+      (ngSubmit)="onWarehouseManagerSubmit()"
+      class="space-y-4"
+    >
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <!-- Username -->
+        <div class="space-y-2">
+          <label
+            for="wm_username"
+            class="block text-sm font-medium text-gray-700"
+            >Username</label
+          >
+          <input
+            type="text"
+            id="wm_username"
+            formControlName="username"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter username"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'username', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Username is required
+          </div>
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'username', 'minlength')"
+            class="text-red-500 text-xs"
+          >
+            Username must be at least 3 characters
+          </div>
+        </div>
+
+        <!-- Email -->
+        <div class="space-y-2">
+          <label for="wm_email" class="block text-sm font-medium text-gray-700"
+            >Email</label
+          >
+          <input
+            type="email"
+            id="wm_email"
+            formControlName="email"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter email"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'email', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Email is required
+          </div>
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'email', 'email')"
+            class="text-red-500 text-xs"
+          >
+            Please enter a valid email
+          </div>
+        </div>
+
+        <!-- Password -->
+        <div class="space-y-2">
+          <label
+            for="wm_password"
+            class="block text-sm font-medium text-gray-700"
+            >Password</label
+          >
+          <input
+            type="password"
+            id="wm_password"
+            formControlName="password"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter password"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'password', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Password is required
+          </div>
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'password', 'minlength')"
+            class="text-red-500 text-xs"
+          >
+            Password must be at least 8 characters
+          </div>
+        </div>
+
+        <!-- First Name -->
+        <div class="space-y-2">
+          <label
+            for="wm_first_name"
+            class="block text-sm font-medium text-gray-700"
+            >First Name</label
+          >
+          <input
+            type="text"
+            id="wm_first_name"
+            formControlName="first_name"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter first name"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'first_name', 'required')"
+            class="text-red-500 text-xs"
+          >
+            First name is required
+          </div>
+        </div>
+
+        <!-- Last Name -->
+        <div class="space-y-2">
+          <label
+            for="wm_last_name"
+            class="block text-sm font-medium text-gray-700"
+            >Last Name</label
+          >
+          <input
+            type="text"
+            id="wm_last_name"
+            formControlName="last_name"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter last name"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'last_name', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Last name is required
+          </div>
+        </div>
+
+        <!-- Warehouse ID -->
+        <div class="space-y-2">
+          <label
+            for="warehouse_id"
+            class="block text-sm font-medium text-gray-700"
+            >Warehouse ID</label
+          >
+          <select
+            id="warehouse_id"
+            formControlName="warehouse_id"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 bg-white"
+          >
+            <option value="" disabled selected>Select warehouse</option>
+            <option value="1">1 - Colombo Central Warehouse</option>
+            <option value="2">2 - Kandy Distribution Center</option>
+            <option value="3">3 - Galle Shipping Hub</option>
+          </select>
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'warehouse_id', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Warehouse ID is required
+          </div>
+        </div>
+
+        <!-- Department -->
+        <div class="space-y-2">
+          <label
+            for="department"
+            class="block text-sm font-medium text-gray-700"
+            >Department</label
+          >
+          <input
+            type="text"
+            id="department"
+            formControlName="department"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter department"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'department', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Department is required
+          </div>
+        </div>
+
+        <!-- Phone -->
+        <div class="space-y-2">
+          <label for="phone" class="block text-sm font-medium text-gray-700"
+            >Phone</label
+          >
+          <input
+            type="tel"
+            id="phone"
+            formControlName="phone"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="Enter phone number"
+          />
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'phone', 'required')"
+            class="text-red-500 text-xs"
+          >
+            Phone number is required
+          </div>
+          <div
+            *ngIf="hasError(warehouseManagerForm, 'phone', 'pattern')"
+            class="text-red-500 text-xs"
+          >
+            Please enter a valid 10-digit phone number
+          </div>
+        </div>
+      </div>
+
+      <div class="flex justify-end mt-6">
+        <button
+          type="submit"
+          [disabled]="isSubmitting"
+          class="px-6 py-2  bg-[#f19249] hover:bg-[#fcd9b1] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 transform hover:scale-105 active:scale-95 shadow-md"
+        >
+          <span class="flex items-center">
+            <svg
+              *ngIf="isSubmitting"
+              class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+            {{ isSubmitting ? "Registering..." : "Register Warehouse Manager" }}
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+

--- a/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.spec.ts
+++ b/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverManagerRegisterComponent } from './driver-manager-register.component';
+
+describe('DriverManagerRegisterComponent', () => {
+  let component: DriverManagerRegisterComponent;
+  let fixture: ComponentFixture<DriverManagerRegisterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverManagerRegisterComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DriverManagerRegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.ts
+++ b/src/app/components/admin-page/driver-manager-register/driver-manager-register.component.ts
@@ -1,0 +1,147 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { RegisterService } from '../../../service/auth/register.service';
+import { HttpClientModule } from '@angular/common/http';
+
+@Component({
+  selector: 'app-driver-manager-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, HttpClientModule],
+  templateUrl: './driver-manager-register.component.html',
+  styleUrl: './driver-manager-register.component.css',
+})
+export class DriverManagerRegisterComponent implements OnInit {
+  driverForm!: FormGroup;
+  warehouseManagerForm!: FormGroup;
+  activeTab: 'driver' | 'warehouseManager' = 'driver';
+  submitStatus: { success: boolean; message: string } | null = null;
+  isSubmitting = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private registerService: RegisterService
+  ) {}
+
+  ngOnInit() {
+    this.initDriverForm();
+    this.initWarehouseManagerForm();
+  }
+
+  initDriverForm() {
+    this.driverForm = this.fb.group({
+      username: ['', [Validators.required, Validators.minLength(3)]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      first_name: ['', Validators.required],
+      last_name: ['', Validators.required],
+      vehicle_id: ['', Validators.required],
+      license_number: ['', Validators.required],
+      vehicle_type: ['lorry', Validators.required],
+    });
+  }
+
+  initWarehouseManagerForm() {
+    this.warehouseManagerForm = this.fb.group({
+      username: ['', [Validators.required, Validators.minLength(3)]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      first_name: ['', Validators.required],
+      last_name: ['', Validators.required],
+      warehouse_id: ['', Validators.required],
+      department: ['', Validators.required],
+      phone: ['', [Validators.required, Validators.pattern(/^\d{10}$/)]],
+    });
+  }
+
+  setActiveTab(tab: 'driver' | 'warehouseManager') {
+    this.activeTab = tab;
+    this.submitStatus = null;
+  }
+
+  onDriverSubmit() {
+    if (this.driverForm.invalid) {
+      this.markFormGroupTouched(this.driverForm);
+      return;
+    }
+
+    const driverData = {
+      ...this.driverForm.value,
+      role_id: 6, // Fixed role ID for drivers
+    };
+
+    this.isSubmitting = true;
+    this.registerService.registerDriver(driverData).subscribe({
+      next: (response) => {
+        this.isSubmitting = false;
+        this.submitStatus = {
+          success: true,
+          message: 'Driver registered successfully!',
+        };
+        this.driverForm.reset();
+        // Reset the form with default values for dropdowns
+        this.driverForm.patchValue({ vehicle_type: 'lorry' });
+      },
+      error: (error) => {
+        this.isSubmitting = false;
+        this.submitStatus = {
+          success: false,
+          message:
+            error.error?.message || 'Registration failed. Please try again.',
+        };
+      },
+    });
+  }
+
+  onWarehouseManagerSubmit() {
+    if (this.warehouseManagerForm.invalid) {
+      this.markFormGroupTouched(this.warehouseManagerForm);
+      return;
+    }
+
+    const warehouseManagerData = {
+      ...this.warehouseManagerForm.value,
+      role_id: 5, // Fixed role ID for warehouse managers
+    };
+
+    this.isSubmitting = true;
+    this.registerService
+      .registerWarehouseManager(warehouseManagerData)
+      .subscribe({
+        next: (response) => {
+          this.isSubmitting = false;
+          this.submitStatus = {
+            success: true,
+            message: 'Warehouse Manager registered successfully!',
+          };
+          this.warehouseManagerForm.reset();
+        },
+        error: (error) => {
+          this.isSubmitting = false;
+          this.submitStatus = {
+            success: false,
+            message:
+              error.error?.message || 'Registration failed. Please try again.',
+          };
+        },
+      });
+  }
+
+  // Helper method to mark all controls as touched
+  private markFormGroupTouched(formGroup: FormGroup) {
+    Object.values(formGroup.controls).forEach((control) => {
+      control.markAsTouched();
+    });
+  }
+
+  // Form validation helpers
+  hasError(form: FormGroup, controlName: string, errorType: string): boolean {
+    const control = form.get(controlName);
+    return control !== null && control.touched && control.hasError(errorType);
+  }
+}

--- a/src/app/components/admin-page/forecast/forecast.component.html
+++ b/src/app/components/admin-page/forecast/forecast.component.html
@@ -1,15 +1,4 @@
 <div class="forecast-container p-6 bg-gray-50 min-h-screen">
-  <div class="absolute inset-0 bg-gradient-to-l from-[#d47153] to-[#fde68a] md:h-[190px]">
-    <div class="absolute bottom-0 left-0 right-0 overflow-hidden">
-      <svg viewBox="0 0 1440 200" class="w-full" preserveAspectRatio="none">
-        <path
-          fill="#ffffff"
-          fill-opacity="1"
-          d="M0,96L80,106.7C160,117,320,139,480,149.3C640,160,800,160,960,138.7C1120,117,1280,75,1360,53.3L1440,32L1440,200L1360,200C1280,200,1120,200,960,200C800,200,640,200,480,200C320,200,160,200,80,200L0,200Z"
-        ></path>
-      </svg>
-    </div>
-  </div>
   <!-- Background Circles -->
   <div class="bg-circle-bottom"></div>
   <div class="bg-circle-center"></div>

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -58,7 +58,14 @@ export class SidebarComponent {
       { label: 'Current Requests', route: '/dashboard/supplier/current-requests' },
       { label: 'Supplier Dashboard', route: '/dashboard/supplier/supplier' },
       { label: 'Profile', route: '/dashboard/supplier/profile' },
-    ]
+    ],
+    1: [ // Admin
+      { label: 'Warehouses', route: '/dashboard/admin/warehouse' },
+      { label: 'Demand Forecast', route: '/dashboard/admin/forecast' },
+      { label: 'Stock Manage', route: '/dashboard/admin/supplier-ranks' },
+      { label: 'Registrations', route: '/dashboard/admin/register' },
+      { label: 'Profile', route: '/dashboard/profile' },
+    ],
   };
 
   // tabs: Tab[] = [

--- a/src/app/components/warehouse-manager-page/supplier-req-survey/supplier-req-survey.component.html
+++ b/src/app/components/warehouse-manager-page/supplier-req-survey/supplier-req-survey.component.html
@@ -478,7 +478,6 @@
                       }"
                     >
                       <div class="flex justify-center mb-2">
-
                         <!-- Received Icon - Blue -->
                         <svg
                           *ngIf="option.value === 'received'"
@@ -524,8 +523,7 @@
                             d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"
                           />
                         </svg>
-
-                        </div>
+                      </div>
 
                       <!-- Status Label Color -->
                       <span
@@ -554,192 +552,225 @@
               </div>
             </div>
 
-            <!-- Enhanced rating UI with modern style - COLLAPSIBLE SECTION -->
+            <!-- Enhanced rating UI with modern style - ALWAYS VISIBLE -->
             <div class="border-t border-gray-200 pt-6">
-              <!-- Collapsible header with toggle button -->
-              <div
-                (click)="toggleSurveyVisibility()"
-                class="flex items-center justify-between cursor-pointer mb-4 group"
+              <h3
+                class="text-lg font-medium text-gray-800 flex items-center mb-4"
               >
-                <h3 class="text-lg font-medium text-gray-800 flex items-center">
-                  <svg
-                    class="h-5 w-5 mr-2 text-blue-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                    />
-                  </svg>
-                  Quality Survey
-                </h3>
-                <div
-                  class="flex items-center text-sm text-blue-600 group-hover:text-blue-800 transition-colors"
+                <svg
+                  class="h-5 w-5 mr-2 text-blue-500"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
                 >
-                  <span>{{
-                    isSurveyVisible ? "Hide Questions" : "Show Questions"
-                  }}</span>
-                  <svg
-                    class="ml-2 h-5 w-5 transition-transform duration-200"
-                    [ngClass]="{ 'transform rotate-180': isSurveyVisible }"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+                Quality Survey
+              </h3>
+
+              <!-- Question 1: Quality Rating (1-10 scale) -->
+              <div
+                class="p-5 border border-gray-100 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 bg-gray-50 mb-6"
+              >
+                <div class="mb-3">
+                  <label
+                    for="question1"
+                    class="block text-base font-medium text-gray-800"
                   >
-                    <path
-                      fill-rule="evenodd"
-                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
+                    1. How is the quality of the goods? (1-10)
+                    <span class="text-red-500">*</span>
+                  </label>
+                </div>
+
+                <!-- Rating selection with numeric scale 1-10 -->
+                <div class="mt-4">
+                  <div class="flex justify-between items-center mb-2">
+                    <span class="text-xs font-medium text-gray-500">Poor</span>
+                    <span class="text-xs font-medium text-gray-500"
+                      >Excellent</span
+                    >
+                  </div>
+
+                  <div class="grid grid-cols-10 gap-1">
+                    <ng-container
+                      *ngFor="let rating of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+                    >
+                      <label
+                        [for]="'q1-rating-' + rating"
+                        class="relative cursor-pointer"
+                      >
+                        <input
+                          type="radio"
+                          [id]="'q1-rating-' + rating"
+                          [value]="rating"
+                          formControlName="question1"
+                          class="sr-only"
+                        />
+                        <div
+                          class="h-12 flex items-center justify-center rounded-lg border transition-all duration-200"
+                          [ngClass]="{
+                            'bg-blue-500 border-blue-600 shadow-inner text-white transform scale-110':
+                              surveyForm.value.question1 === rating,
+                            'border-gray-200 text-gray-600 hover:bg-gray-100':
+                              surveyForm.value.question1 !== rating
+                          }"
+                        >
+                          {{ rating }}
+                        </div>
+                        <div
+                          class="mt-2 text-center text-xs font-medium"
+                          [ngClass]="{
+                            'text-blue-700':
+                              surveyForm.value.question1 === rating,
+                            'text-transparent':
+                              surveyForm.value.question1 !== rating
+                          }"
+                        >
+                          <ng-container
+                            *ngIf="surveyForm.value.question1 === rating"
+                            >{{ rating }}</ng-container
+                          >
+                        </div>
+                      </label>
+                    </ng-container>
+                  </div>
+
+                  <!-- Display selected rating label below -->
+                  <div
+                    *ngIf="surveyForm.value.question1"
+                    class="mt-3 text-center text-sm font-medium text-blue-700"
+                  >
+                    {{ getRatingLabel(surveyForm.value.question1) }}
+                  </div>
+
+                  <!-- Validation message -->
+                  <div
+                    *ngIf="
+                      surveyForm.get('question1')?.invalid &&
+                      surveyForm.get('question1')?.touched
+                    "
+                    class="mt-2 text-sm text-red-600"
+                  >
+                    Please select a quality rating
+                  </div>
                 </div>
               </div>
 
-              <!-- Collapsible survey questions -->
-              <div *ngIf="isSurveyVisible" class="space-y-8 animate-fade-in">
-                <div
-                  *ngFor="let question of questions; let i = index"
-                  class="p-5 border border-gray-100 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 bg-gray-50"
-                >
-                  <div class="mb-3">
-                    <label
-                      [for]="'question' + (i + 1)"
-                      class="block text-base font-medium text-gray-800"
-                    >
-                      {{ i + 1 }}. {{ question }}
+              <!-- Question 2: Yes/No Question -->
+              <div
+                class="p-5 border border-gray-100 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 bg-gray-50 mb-6"
+              >
+                <div class="mb-3">
+                  <label
+                    for="question2"
+                    class="block text-base font-medium text-gray-800"
+                  >
+                    2. Any Issues/ Noticable Defects?
+                    <span class="text-red-500">*</span>
+                  </label>
+                </div>
+
+                <!-- Yes/No radio options -->
+                <div class="mt-4">
+                  <div class="flex space-x-4">
+                    <label for="q2-yes" class="flex-1 relative cursor-pointer">
+                      <input
+                        type="radio"
+                        id="q2-yes"
+                        [value]="true"
+                        formControlName="question2"
+                        class="sr-only"
+                      />
+                      <div
+                        class="h-12 flex items-center justify-center rounded-lg border transition-all duration-200"
+                        [ngClass]="{
+                          'bg-red-500 border-red-600 shadow-inner text-white transform scale-110':
+                            surveyForm.value.question2 === true,
+                          'border-gray-200 text-gray-600 hover:bg-gray-100':
+                            surveyForm.value.question2 !== true
+                        }"
+                      >
+                        <svg
+                          *ngIf="surveyForm.value.question2 === true"
+                          class="h-5 w-5 mr-1 text-white"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                            clip-rule="evenodd"
+                          />
+                        </svg>
+                        Yes
+                      </div>
+                    </label>
+
+                    <label for="q2-no" class="flex-1 relative cursor-pointer">
+                      <input
+                        type="radio"
+                        id="q2-no"
+                        [value]="false"
+                        formControlName="question2"
+                        class="sr-only"
+                      />
+                      <div
+                        class="h-12 flex items-center justify-center rounded-lg border transition-all duration-200"
+                        [ngClass]="{
+                          'bg-green-500 border-green-600 shadow-inner text-white transform scale-110':
+                            surveyForm.value.question2 === false,
+                          'border-gray-200 text-gray-600 hover:bg-gray-100':
+                            surveyForm.value.question2 !== false
+                        }"
+                      >
+                        <svg
+                          *ngIf="surveyForm.value.question2 === false"
+                          class="h-5 w-5 mr-1 text-white"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                            clip-rule="evenodd"
+                          />
+                        </svg>
+                        No
+                      </div>
                     </label>
                   </div>
 
-                  <!-- Enhanced rating selection with stars -->
-                  <div class="mt-4">
-                    <div class="flex justify-between items-center mb-2">
-                      <span class="text-xs font-medium text-gray-500"
-                        >Poor</span
-                      >
-                      <span class="text-xs font-medium text-gray-500"
-                        >Excellent</span
-                      >
-                    </div>
-
-                    <div class="flex space-x-2">
-                      <ng-container *ngFor="let rating of [1, 2, 3, 4, 5]">
-                        <label
-                          [for]="'q' + (i + 1) + '-rating-' + rating"
-                          class="flex-1 relative cursor-pointer"
-                        >
-                          <input
-                            type="radio"
-                            [id]="'q' + (i + 1) + '-rating-' + rating"
-                            [value]="rating"
-                            [formControlName]="'question' + (i + 1)"
-                            class="sr-only"
-                          />
-                          <div
-                            class="h-12 flex items-center justify-center rounded-lg border transition-all duration-200"
-                            [ngClass]="{
-                              'bg-blue-500 border-blue-600 shadow-inner text-white transform scale-110':
-                                surveyForm.value['question' + (i + 1)] ===
-                                rating,
-                              'border-gray-200 text-gray-600 hover:bg-gray-100':
-                                surveyForm.value['question' + (i + 1)] !==
-                                rating
-                            }"
-                          >
-                            <svg
-                              *ngIf="
-                                surveyForm.value['question' + (i + 1)] ===
-                                rating
-                              "
-                              class="h-5 w-5 mr-1 text-white"
-                              xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                            >
-                              <path
-                                d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
-                              />
-                            </svg>
-                            {{ rating }}
-                          </div>
-                          <div
-                            class="mt-2 text-center text-xs font-medium"
-                            [ngClass]="{
-                              'text-blue-700':
-                                surveyForm.value['question' + (i + 1)] ===
-                                rating,
-                              'text-transparent':
-                                surveyForm.value['question' + (i + 1)] !==
-                                rating
-                            }"
-                          >
-                            {{
-                              rating === surveyForm.value["question" + (i + 1)]
-                                ? getRatingLabel(rating)
-                                : "&nbsp;"
-                            }}
-                          </div>
-                        </label>
-                      </ng-container>
-                    </div>
+                  <!-- Validation message -->
+                  <div
+                    *ngIf="
+                      surveyForm.get('question2')?.invalid &&
+                      surveyForm.get('question2')?.touched
+                    "
+                    class="mt-2 text-sm text-red-600"
+                  >
+                    Please select Yes or No
                   </div>
                 </div>
               </div>
+            </div>
 
-              <!-- Enhanced comments box - ALWAYS VISIBLE -->
-              <div class="mt-8">
-                <label
-                  for="comments"
-                  class="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  <div class="flex items-center">
-                    <svg
-                      class="h-5 w-5 mr-2 text-gray-500"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
-                      />
-                    </svg>
-                    Additional Comments (Optional)
-                  </div>
-                </label>
-                <textarea
-                  id="comments"
-                  formControlName="comments"
-                  rows="4"
-                  class="mt-1 text-stone-400 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-lg transition-all duration-200"
-                  placeholder="Share any additional thoughts about this order..."
-                ></textarea>
-              </div>
-
-              <!-- Enhanced submit button with animation - ALWAYS VISIBLE -->
-              <div class="mt-8 flex justify-end">
-                <button
-                  type="button"
-                  (click)="goBack()"
-                  class="bg-white py-2 px-4 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mr-4 transition-all duration-200"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  [disabled]="surveyForm.invalid || submitSuccess"
-                  class="inline-flex justify-center items-center py-2 px-6 border border-transparent shadow-sm text-sm font-medium rounded-lg text-white bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
-                >
+            <!-- Enhanced comments box - ALWAYS VISIBLE -->
+            <div class="mt-8">
+              <label
+                for="comments"
+                class="block text-sm font-medium text-gray-700 mb-2"
+              >
+                <div class="flex items-center">
                   <svg
-                    *ngIf="!submitSuccess"
-                    class="mr-2 h-4 w-4"
+                    class="h-5 w-5 mr-2 text-gray-500"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
                     viewBox="0 0 24 24"
@@ -749,33 +780,73 @@
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       stroke-width="2"
-                      d="M5 13l4 4L19 7"
+                      d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
                     />
                   </svg>
-                  <svg
-                    *ngIf="submitSuccess"
-                    class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      class="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      stroke-width="4"
-                    ></circle>
-                    <path
-                      class="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  {{ submitSuccess ? "Submitting..." : "Submit Review" }}
-                </button>
-              </div>
+                  Additional Comments (Optional)
+                </div>
+              </label>
+              <textarea
+                id="comments"
+                formControlName="comments"
+                rows="4"
+                class="mt-1 p-2 text-stone-800 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-lg transition-all duration-200"
+                placeholder="Share any additional thoughts about this order..."
+              ></textarea>
+            </div>
+
+            <!-- Enhanced submit button with animation - ALWAYS VISIBLE -->
+            <div class="mt-8 flex justify-end">
+              <button
+                type="button"
+                (click)="goBack()"
+                class="bg-white py-2 px-4 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mr-4 transition-all duration-200"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                [disabled]="surveyForm.invalid || submitSuccess"
+                class="inline-flex justify-center items-center py-2 px-6 border border-transparent shadow-sm text-sm font-medium rounded-lg text-white bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+              >
+                <svg
+                  *ngIf="!submitSuccess"
+                  class="mr-2 h-4 w-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <svg
+                  *ngIf="submitSuccess"
+                  class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  ></circle>
+                  <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                {{ submitSuccess ? "Submitting..." : "Submit Review" }}
+              </button>
             </div>
           </form>
         </div>

--- a/src/app/components/warehouse-manager-page/supplier-req/supplier-req.component.ts
+++ b/src/app/components/warehouse-manager-page/supplier-req/supplier-req.component.ts
@@ -6,11 +6,16 @@ import {
   SupplierRequestService,
   SupplierRequest,
 } from '../../../service/order/supplier-request.service';
+import { HttpClientModule } from '@angular/common/http';
 
 @Component({
   selector: 'app-supplier-req',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    HttpClientModule, // Add this import
+  ],
   templateUrl: './supplier-req.component.html',
   styleUrl: './supplier-req.component.css',
 })

--- a/src/app/service/auth/register.service.spec.ts
+++ b/src/app/service/auth/register.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RegisterService } from './register.service';
+
+describe('RegisterService', () => {
+  let service: RegisterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RegisterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/service/auth/register.service.ts
+++ b/src/app/service/auth/register.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface DriverRegistration {
+  username: string;
+  email: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  vehicle_id: string;
+  license_number: string;
+  vehicle_type: string;
+  role_id: number;
+}
+
+export interface WarehouseManagerRegistration {
+  username: string;
+  email: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  warehouse_id: string;
+  department: string;
+  phone: string;
+  role_id: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RegisterService {
+  private apiUrl = 'http://localhost:8000/api/v1/register/';
+
+  constructor(private http: HttpClient) {}
+
+  registerDriver(data: DriverRegistration): Observable<any> {
+    console.log('Registering driver:', data); // Debugging line
+    return this.http.post(this.apiUrl, data);
+  }
+
+  registerWarehouseManager(
+    data: WarehouseManagerRegistration
+  ): Observable<any> {
+    console.log('Registering warehouse manager:', data); // Debugging line
+    return this.http.post(this.apiUrl, data);
+  }
+}

--- a/src/app/service/order/supplier-request.service.ts
+++ b/src/app/service/order/supplier-request.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { catchError } from 'rxjs/operators';
 
 export interface SupplierRequest {
   request_id: number;
   supplier_name: string;
+  supplier_id: number; // Make this required, not optional
   created_at: string;
   expected_delivery_date: string;
   product_name: string;
+  product_id: number; // Make this required, not optional
   count: number;
   status: string;
   received_at: string | null;
@@ -19,11 +23,21 @@ export interface SurveySubmission {
   status: string;
   surveyResponses: {
     question1: number;
-    question2: number;
-    question3: number;
-    question4: number;
-    question5: number;
+    question2: boolean;
   };
+  comments: string;
+}
+
+// Update the interface to match the API requirements
+export interface DeliverySubmission {
+  requestId: number;
+  product_id: number;
+  supplier_id: number;
+  warehouse_id: number;
+  quantity: number;
+  status: string;
+  is_defective: boolean;
+  quality: number;
   comments: string;
 }
 
@@ -31,13 +45,18 @@ export interface SurveySubmission {
   providedIn: 'root',
 })
 export class SupplierRequestService {
+  private apiUrl = 'http://localhost:8000/api'; // Replace with your actual API URL
+
+  // Fix the mock data declaration - make it a private property
   private mockData: SupplierRequest[] = [
     {
       request_id: 1,
       supplier_name: 'Supplier A',
+      supplier_id: 101,
       created_at: '2025-05-01',
       expected_delivery_date: '2025-05-05',
       product_name: 'Product 1',
+      product_id: 1,
       count: 1200.0,
       status: 'pending',
       received_at: null,
@@ -47,354 +66,412 @@ export class SupplierRequestService {
     {
       request_id: 2,
       supplier_name: 'Supplier B',
+      supplier_id: 102,
       created_at: '2025-05-02',
       expected_delivery_date: '2025-05-06',
       product_name: 'Product 2',
-      count: 1300.0,
+      product_id: 2,
+      count: 1250.0,
       status: 'received',
       received_at: '2025-05-06',
       warehouse_id: 1,
-      unit_price: 45.0,
+      unit_price: 49.0,
     },
     {
       request_id: 3,
       supplier_name: 'Supplier C',
+      supplier_id: 103,
       created_at: '2025-05-03',
       expected_delivery_date: '2025-05-07',
       product_name: 'Product 3',
-      count: 1400.0,
+      product_id: 3,
+      count: 1300.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 1,
-      unit_price: 40.0,
+      unit_price: 48.0,
     },
     {
       request_id: 4,
       supplier_name: 'Supplier D',
+      supplier_id: 104,
       created_at: '2025-05-04',
       expected_delivery_date: '2025-05-08',
       product_name: 'Product 4',
-      count: 1500.0,
+      product_id: 4,
+      count: 1350.0,
       status: 'received',
       received_at: '2025-05-08',
       warehouse_id: 1,
-      unit_price: 35.0,
+      unit_price: 47.0,
     },
     {
       request_id: 5,
       supplier_name: 'Supplier E',
+      supplier_id: 105,
       created_at: '2025-05-05',
       expected_delivery_date: '2025-05-09',
       product_name: 'Product 5',
-      count: 1600.0,
+      product_id: 5,
+      count: 1400.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 1,
-      unit_price: 30.0,
+      unit_price: 46.0,
     },
     {
       request_id: 6,
       supplier_name: 'Supplier F',
+      supplier_id: 106,
       created_at: '2025-05-06',
       expected_delivery_date: '2025-05-10',
       product_name: 'Product 6',
-      count: 1700.0,
+      product_id: 6,
+      count: 1450.0,
       status: 'received',
       received_at: '2025-05-10',
       warehouse_id: 1,
-      unit_price: 25.0,
+      unit_price: 45.0,
     },
     {
       request_id: 7,
       supplier_name: 'Supplier G',
+      supplier_id: 107,
       created_at: '2025-05-07',
       expected_delivery_date: '2025-05-11',
       product_name: 'Product 7',
-      count: 1800.0,
+      product_id: 7,
+      count: 1500.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 1,
-      unit_price: 20.0,
+      unit_price: 44.0,
     },
     {
       request_id: 8,
       supplier_name: 'Supplier H',
+      supplier_id: 108,
       created_at: '2025-05-08',
       expected_delivery_date: '2025-05-12',
       product_name: 'Product 8',
-      count: 1900.0,
+      product_id: 8,
+      count: 1550.0,
       status: 'received',
       received_at: '2025-05-12',
       warehouse_id: 1,
-      unit_price: 15.0,
+      unit_price: 43.0,
     },
     {
       request_id: 9,
       supplier_name: 'Supplier I',
+      supplier_id: 109,
       created_at: '2025-05-09',
       expected_delivery_date: '2025-05-13',
       product_name: 'Product 9',
-      count: 2000.0,
+      product_id: 9,
+      count: 1600.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 1,
-      unit_price: 10.0,
+      unit_price: 42.0,
     },
     {
       request_id: 10,
       supplier_name: 'Supplier J',
+      supplier_id: 110,
       created_at: '2025-05-10',
       expected_delivery_date: '2025-05-14',
       product_name: 'Product 10',
-      count: 2100.0,
+      product_id: 10,
+      count: 1650.0,
       status: 'received',
       received_at: '2025-05-14',
       warehouse_id: 1,
-      unit_price: 5.0,
+      unit_price: 41.0,
     },
     {
       request_id: 11,
       supplier_name: 'Supplier A',
+      supplier_id: 101,
       created_at: '2025-05-01',
       expected_delivery_date: '2025-05-05',
       product_name: 'Product 1',
-      count: 1250.0,
+      product_id: 1,
+      count: 1700.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 2,
-      unit_price: 51.0,
+      unit_price: 40.0,
     },
     {
       request_id: 12,
       supplier_name: 'Supplier B',
+      supplier_id: 102,
       created_at: '2025-05-02',
       expected_delivery_date: '2025-05-06',
       product_name: 'Product 2',
-      count: 1350.0,
+      product_id: 2,
+      count: 1750.0,
       status: 'received',
       received_at: '2025-05-06',
       warehouse_id: 2,
-      unit_price: 46.0,
+      unit_price: 39.0,
     },
     {
       request_id: 13,
       supplier_name: 'Supplier C',
+      supplier_id: 103,
       created_at: '2025-05-03',
       expected_delivery_date: '2025-05-07',
       product_name: 'Product 3',
-      count: 1450.0,
+      product_id: 3,
+      count: 1800.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 2,
-      unit_price: 41.0,
+      unit_price: 38.0,
     },
     {
       request_id: 14,
       supplier_name: 'Supplier D',
+      supplier_id: 104,
       created_at: '2025-05-04',
       expected_delivery_date: '2025-05-08',
       product_name: 'Product 4',
-      count: 1550.0,
+      product_id: 4,
+      count: 1850.0,
       status: 'received',
       received_at: '2025-05-08',
       warehouse_id: 2,
-      unit_price: 36.0,
+      unit_price: 37.0,
     },
     {
       request_id: 15,
       supplier_name: 'Supplier E',
+      supplier_id: 105,
       created_at: '2025-05-05',
       expected_delivery_date: '2025-05-09',
       product_name: 'Product 5',
-      count: 1650.0,
+      product_id: 5,
+      count: 1900.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 2,
-      unit_price: 31.0,
+      unit_price: 36.0,
     },
     {
       request_id: 16,
       supplier_name: 'Supplier F',
+      supplier_id: 106,
       created_at: '2025-05-06',
       expected_delivery_date: '2025-05-10',
       product_name: 'Product 6',
-      count: 1750.0,
+      product_id: 6,
+      count: 1950.0,
       status: 'received',
       received_at: '2025-05-10',
       warehouse_id: 2,
-      unit_price: 26.0,
+      unit_price: 35.0,
     },
     {
       request_id: 17,
       supplier_name: 'Supplier G',
+      supplier_id: 107,
       created_at: '2025-05-07',
       expected_delivery_date: '2025-05-11',
       product_name: 'Product 7',
-      count: 1850.0,
+      product_id: 7,
+      count: 2000.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 2,
-      unit_price: 21.0,
+      unit_price: 34.0,
     },
     {
       request_id: 18,
       supplier_name: 'Supplier H',
+      supplier_id: 108,
       created_at: '2025-05-08',
       expected_delivery_date: '2025-05-12',
       product_name: 'Product 8',
-      count: 1950.0,
+      product_id: 8,
+      count: 2050.0,
       status: 'received',
       received_at: '2025-05-12',
       warehouse_id: 2,
-      unit_price: 16.0,
+      unit_price: 33.0,
     },
     {
       request_id: 19,
       supplier_name: 'Supplier I',
+      supplier_id: 109,
       created_at: '2025-05-09',
       expected_delivery_date: '2025-05-13',
       product_name: 'Product 9',
-      count: 2050.0,
+      product_id: 9,
+      count: 2100.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 2,
-      unit_price: 11.0,
+      unit_price: 32.0,
     },
     {
       request_id: 20,
       supplier_name: 'Supplier J',
+      supplier_id: 110,
       created_at: '2025-05-10',
       expected_delivery_date: '2025-05-14',
       product_name: 'Product 10',
+      product_id: 10,
       count: 2150.0,
       status: 'received',
       received_at: '2025-05-14',
       warehouse_id: 2,
-      unit_price: 6.0,
+      unit_price: 31.0,
     },
     {
       request_id: 21,
       supplier_name: 'Supplier A',
+      supplier_id: 101,
       created_at: '2025-05-01',
       expected_delivery_date: '2025-05-05',
       product_name: 'Product 1',
-      count: 1220.0,
+      product_id: 1,
+      count: 2200.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 3,
-      unit_price: 52.0,
+      unit_price: 30.0,
     },
     {
       request_id: 22,
       supplier_name: 'Supplier B',
+      supplier_id: 102,
       created_at: '2025-05-02',
       expected_delivery_date: '2025-05-06',
       product_name: 'Product 2',
-      count: 1320.0,
+      product_id: 2,
+      count: 2250.0,
       status: 'received',
       received_at: '2025-05-06',
       warehouse_id: 3,
-      unit_price: 47.0,
+      unit_price: 29.0,
     },
     {
       request_id: 23,
       supplier_name: 'Supplier C',
+      supplier_id: 103,
       created_at: '2025-05-03',
       expected_delivery_date: '2025-05-07',
       product_name: 'Product 3',
-      count: 1420.0,
+      product_id: 3,
+      count: 2300.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 3,
-      unit_price: 42.0,
+      unit_price: 28.0,
     },
     {
       request_id: 24,
       supplier_name: 'Supplier D',
+      supplier_id: 104,
       created_at: '2025-05-04',
       expected_delivery_date: '2025-05-08',
       product_name: 'Product 4',
-      count: 1520.0,
+      product_id: 4,
+      count: 2350.0,
       status: 'received',
       received_at: '2025-05-08',
-      warehouse_id: 3,
-      unit_price: 37.0,
-    },
-    {
-      request_id: 25,
-      supplier_name: 'Supplier E',
-      created_at: '2025-05-05',
-      expected_delivery_date: '2025-05-09',
-      product_name: 'Product 5',
-      count: 1620.0,
-      status: 'pending',
-      received_at: null,
-      warehouse_id: 3,
-      unit_price: 32.0,
-    },
-    {
-      request_id: 26,
-      supplier_name: 'Supplier F',
-      created_at: '2025-05-06',
-      expected_delivery_date: '2025-05-10',
-      product_name: 'Product 6',
-      count: 1720.0,
-      status: 'received',
-      received_at: '2025-05-10',
       warehouse_id: 3,
       unit_price: 27.0,
     },
     {
+      request_id: 25,
+      supplier_name: 'Supplier E',
+      supplier_id: 105,
+      created_at: '2025-05-05',
+      expected_delivery_date: '2025-05-09',
+      product_name: 'Product 5',
+      product_id: 5,
+      count: 2400.0,
+      status: 'pending',
+      received_at: null,
+      warehouse_id: 3,
+      unit_price: 26.0,
+    },
+    {
+      request_id: 26,
+      supplier_name: 'Supplier F',
+      supplier_id: 106,
+      created_at: '2025-05-06',
+      expected_delivery_date: '2025-05-10',
+      product_name: 'Product 6',
+      product_id: 6,
+      count: 2450.0,
+      status: 'received',
+      received_at: '2025-05-10',
+      warehouse_id: 3,
+      unit_price: 25.0,
+    },
+    {
       request_id: 27,
       supplier_name: 'Supplier G',
+      supplier_id: 107,
       created_at: '2025-05-07',
       expected_delivery_date: '2025-05-11',
       product_name: 'Product 7',
-      count: 1820.0,
+      product_id: 7,
+      count: 2500.0,
+      status: 'pending',
+      received_at: null,
+      warehouse_id: 3,
+      unit_price: 24.0,
+    },
+    {
+      request_id: 28,
+      supplier_name: 'Supplier H',
+      supplier_id: 108,
+      created_at: '2025-05-08',
+      expected_delivery_date: '2025-05-12',
+      product_name: 'Product 8',
+      product_id: 8,
+      count: 2550.0,
+      status: 'received',
+      received_at: '2025-05-12',
+      warehouse_id: 3,
+      unit_price: 23.0,
+    },
+    {
+      request_id: 29,
+      supplier_name: 'Supplier I',
+      supplier_id: 109,
+      created_at: '2025-05-09',
+      expected_delivery_date: '2025-05-13',
+      product_name: 'Product 9',
+      product_id: 9,
+      count: 2600.0,
       status: 'pending',
       received_at: null,
       warehouse_id: 3,
       unit_price: 22.0,
     },
     {
-      request_id: 28,
-      supplier_name: 'Supplier H',
-      created_at: '2025-05-08',
-      expected_delivery_date: '2025-05-12',
-      product_name: 'Product 8',
-      count: 1920.0,
-      status: 'received',
-      received_at: '2025-05-12',
-      warehouse_id: 3,
-      unit_price: 17.0,
-    },
-    {
-      request_id: 29,
-      supplier_name: 'Supplier I',
-      created_at: '2025-05-09',
-      expected_delivery_date: '2025-05-13',
-      product_name: 'Product 9',
-      count: 2020.0,
-      status: 'pending',
-      received_at: null,
-      warehouse_id: 3,
-      unit_price: 12.0,
-    },
-    {
       request_id: 30,
       supplier_name: 'Supplier J',
+      supplier_id: 110,
       created_at: '2025-05-10',
       expected_delivery_date: '2025-05-14',
       product_name: 'Product 10',
-      count: 2120.0,
+      product_id: 10,
+      count: 2650.0,
       status: 'received',
       received_at: '2025-05-14',
       warehouse_id: 3,
-      unit_price: 7.0,
+      unit_price: 21.0,
     },
   ];
 
-  constructor() {}
+  constructor(private http: HttpClient) {}
 
   // Get all requests
   getAllRequests(): Observable<SupplierRequest[]> {
@@ -454,4 +531,53 @@ export class SupplierRequestService {
       message: `Order #${survey.requestId} has been updated to ${survey.status}`,
     });
   }
+
+  // Add this method to make the real API call
+  markDeliveryReceived(
+    data: DeliverySubmission
+  ): Observable<{ success: boolean; message: string }> {
+    console.log('Sending data to API:', data);
+
+    // Convert boolean to string for is_defective as required by API
+    const apiPayload = {
+      ...data,
+      is_defective: data.is_defective.toString().toLowerCase(),
+    };
+
+    console.log('API Payload:', apiPayload);
+
+    return this.http
+      .post<{ success: boolean; message: string }>(
+        `${this.apiUrl}/warehouse/mark-delivery-received/`,
+        apiPayload
+      )
+      .pipe(
+        catchError((error) => {
+          console.error('Error submitting delivery status:', error);
+
+          // Update mock data to reflect the change
+          this.updateMockData(data);
+
+          return of({
+            success: false,
+            message: error.error?.message || 'Failed to update delivery status',
+          });
+        })
+      );
+  }
+
+  // Helper method to update mock data when API call fails
+  private updateMockData(data: DeliverySubmission): void {
+    const request = this.mockData.find(
+      (req) => req.request_id === data.requestId
+    );
+    if (request) {
+      request.status = data.status;
+      if (data.status === 'received') {
+        request.received_at = new Date().toISOString().split('T')[0];
+      }
+    }
+  }
+
+  // Other existing methods remain unchanged
 }


### PR DESCRIPTION
This pull request introduces a new `DriverManagerRegisterComponent` for managing driver and warehouse manager registrations, updates the application configuration and routing, and makes various UI and functionality improvements. Below is a summary of the most important changes:

### New Feature: Driver and Warehouse Manager Registration

* Added a new `DriverManagerRegisterComponent` to handle the registration of drivers and warehouse managers, including form validation, submission logic, and integration with the `RegisterService`. (`src/app/components/admin-page/driver-manager-register/driver-manager-register.component.ts`, [src/app/components/admin-page/driver-manager-register/driver-manager-register.component.tsR1-R147](diffhunk://#diff-93438c3601bf2c2a1668787cdc95be542ce0471cd9f0a6df66a013296359be19R1-R147))
* Added corresponding styles for animations and input hover/focus effects in `driver-manager-register.component.css`.
* Created unit tests for the new component in `driver-manager-register.component.spec.ts`.

### Application Configuration and Routing Updates

* Updated `app.config.ts` to include `provideHttpClient` with dependency injection interceptors.
* Updated `app.routes.ts` to add a new route for the `DriverManagerRegisterComponent` under the path `/register`. [[1]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcR24) [[2]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcR80)
* Added a new "Registrations" tab to the admin sidebar in `sidebar.component.ts`.

### UI Enhancements and Code Cleanup

* Removed redundant gradient background SVG in `forecast.component.html` to simplify the UI.
* Improved the supplier request survey UI by making the rating section always visible and adding a 1-10 numeric scale for quality ratings. Enhanced the second question with Yes/No options and validation messages. (`supplier-req-survey.component.html`, [[1]](diffhunk://#diff-a0f1a97d7be9e284207fb876b9934057ec6132f191faa5bcc3a548a45d0553e7L481) [[2]](diffhunk://#diff-a0f1a97d7be9e284207fb876b9934057ec6132f191faa5bcc3a548a45d0553e7L527) [[3]](diffhunk://#diff-a0f1a97d7be9e284207fb876b9934057ec6132f191faa5bcc3a548a45d0553e7L557-L564) [[4]](diffhunk://#diff-a0f1a97d7be9e284207fb876b9934057ec6132f191faa5bcc3a548a45d0553e7L581-R759)